### PR TITLE
GitHub Action: Bump setup-miniconda to v3, to support libmamba solver for conda

### DIFF
--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -5,7 +5,7 @@ on:
       - dev
   pull_request:
     # Sequence of patterns matched against refs/heads
-    branches:    
+    branches:
       - main
 
 
@@ -55,9 +55,10 @@ jobs:
 
       - name: Set up miniconda
         if: matrix.profile == 'conda'
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
+          conda-solver: libmamba
           channels: conda-forge,bioconda,defaults
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
 Set solver to libmamba explicitly, even though I'm not 100% sure it's necessary.