### PR TITLE
change zcat command to also work on MACs

### DIFF
--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -18,27 +18,27 @@ process download_host {
   """
   if [ $host == 'hsa' ]; then
     wget ftp://ftp.ensembl.org/pub/release-99/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
-    zcat *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
+    zcat < *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
   fi
   if [ $host == 'mmu' ]; then
     wget ftp://ftp.ensembl.org/pub/release-99/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna.primary_assembly.fa.gz
-    zcat *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
+    zcat < *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
   fi
   if [ $host == 'cli' ]; then
     wget ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/337/935/GCF_000337935.1_Cliv_1.0/GCF_000337935.1_Cliv_1.0_genomic.fna.gz
-    zcat *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
+    zcat < *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
   fi
   if [ $host == 'csa' ]; then
     wget ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/409/795/GCF_000409795.2_Chlorocebus_sabeus_1.1/GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic.fna.gz
-    zcat *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
+    zcat < *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
   fi
   if [ $host == 'gga' ]; then
     wget ftp://ftp.ensembl.org/pub/release-99/fasta/gallus_gallus/dna/Gallus_gallus.GRCg6a.dna.toplevel.fa.gz
-    zcat *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
+    zcat < *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
   fi
   if [ $host == 'eco' ]; then
     wget ftp://ftp.ensemblgenomes.org/pub/release-45/bacteria//fasta/bacteria_90_collection/escherichia_coli_k_12/dna/Escherichia_coli_k_12.ASM80076v1.dna.toplevel.fa.gz
-    zcat *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
+    zcat < *.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
   fi
   if [ $host == 'sc2' ]; then
     wget "https://www.ebi.ac.uk/ena/browser/api/fasta/MN908947.3?download=true" -O sc2.fa
@@ -69,7 +69,7 @@ process check_own {
     # now $fasta'.gz'
   else
     mv ${fasta} ${fasta}.tmp
-    zcat ${fasta}.tmp | sed -e '\$a\\' | bgzip -@ ${task.cpus} -c > ${fasta}.gz
+    zcat < ${fasta}.tmp | sed -e '\$a\\' | bgzip -@ ${task.cpus} -c > ${fasta}.gz
   fi
   """
   stub:
@@ -99,7 +99,7 @@ process concat_contamination {
     for FASTA in ${fastas}
     do
         NAME="\${FASTA%%.*}"
-        zcat \$FASTA | awk -v n=\$NAME '/>/{sub(">","&"n"_")}1' | bgzip -@ ${task.cpus} -c >> db.fa.gz
+        zcat < \$FASTA | awk -v n=\$NAME '/>/{sub(">","&"n"_")}1' | bgzip -@ ${task.cpus} -c >> db.fa.gz
     done
   else
     mv ${fastas} db.fa.gz


### PR DESCRIPTION
On Mac OS `zcat foo.fa` does not work so I changed it to `zcat < foo.fa`.

I did not test it but this should also work on Linux, or? 