### PR TITLE
Fix zcat problems on mac

### DIFF
--- a/data/rRNA/readme.md
+++ b/data/rRNA/readme.md
@@ -1,3 +1,3 @@
 Fasta files downloaded from https://github.com/biocore/sortmerna/tree/master/data/rRNA_databases [2020-05-20]
 Files were rezipped with bgzip:
-for rrna in `ls data/rRNA/*.fasta.gz`; do zcat data/rRNA/$rrna | bgzip -@ 8 -c > data/rRNA/$rrna; done
+for rrna in `ls data/rRNA/*.fasta.gz`; do zcat < data/rRNA/$rrna | bgzip -@ 8 -c > data/rRNA/$rrna; done

--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -40,7 +40,7 @@ process download_host {
       ;;
   esac
 
-  zcat host-temp.fa.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
+  zcat < host-temp.fa.gz | bgzip -@ ${task.cpus} -c > ${host}.fa.gz
   """
   stub:
   """

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -11,8 +11,8 @@ process get_number_of_records {
   if ( params.lib_pairedness == 'paired' ) {
     """
     if [[ ${reads[0]} =~ \\.gz\$ ]]; then
-      TOTALRECORDS_1=\$(zcat ${reads[0]} | echo \$((`wc -l`/4)))
-      TOTALRECORDS_2=\$(zcat ${reads[1]} | echo \$((`wc -l`/4)))
+      TOTALRECORDS_1=\$(zcat < ${reads[0]} | echo \$((`wc -l`/4)))
+      TOTALRECORDS_2=\$(zcat < ${reads[1]} | echo \$((`wc -l`/4)))
     else
       TOTALRECORDS_1=\$(cat ${reads[0]} | echo \$((`wc -l`/4)))
       TOTALRECORDS_2=\$(cat ${reads[1]} | echo \$((`wc -l`/4)))
@@ -22,7 +22,7 @@ process get_number_of_records {
   } else if ( params.lib_pairedness == 'single' && params.input_type != 'fasta' ) {
     """
     if [[ ${reads} =~ \\.gz\$ ]]; then
-      TOTALRECORDS=\$(zcat ${reads} | echo \$((`wc -l`/4)))
+      TOTALRECORDS=\$(zcat < ${reads} | echo \$((`wc -l`/4)))
     else
       TOTALRECORDS=\$(cat ${reads} | echo \$((`wc -l`/4)))
     fi


### PR DESCRIPTION
Closes #74 

`zcat file.gz | ...` doesn't work for some reason on Mac. Needed to switch to `zcat < file.gz | ...`