### PR TITLE
Change host genome index type (samtools --fai-idx) to work with IGV

### DIFF
--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -96,7 +96,7 @@ process concat_contamination {
   """
   # Combine input files, rename duplicate sequences (by id) if found, and compress
   seqkit seq ${fastas} | seqkit rename | bgzip -@ ${task.cpus} -c > db.fa.gz
-  samtools faidx db.fa.gz --gzi-idx db.fa.fai
+  samtools faidx db.fa.gz --fai-idx db.fa.fai
   """
   stub:
   """


### PR DESCRIPTION
Change the host fasta index file format from `gzi` to `fai`, since the former can not be used by IGV. Note that the host.fa.gz file needs to be decompressed before you can view it in IGV (should we update the README?).

Closes #74 