### PR TITLE
Set default branch to 'main' instead of the Nextflow default 'master'

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,7 @@
 manifest {
     mainScript = 'clean.nf'
     nextflowVersion = '>=21.04.0'
+    defaultBranch = 'main'
 }
 
 // default parameters


### PR DESCRIPTION
This came up in relation to changing the default branch within GitHub. I don't think that would have made a difference for Nextflow, because the hard coded default branch is 'master'. This commit changes that default for the clean pipeline to the 'main' branch.

See: https://www.nextflow.io/docs/latest/config.html#scope-manifest