### PR TITLE
Remove 'conda clean' from GitHub action to avoid random crashes

### DIFF
--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -64,10 +64,6 @@ jobs:
           channels: conda-forge,bioconda,defaults
           python-version: ${{ matrix.python-version }}
 
-      - name: Conda clean
-        if: matrix.profile == 'conda'
-        run: conda clean -a
-
       - name: Run nf-test
         run: nf-test test --profile=${{ matrix.profile }} tests/${{ matrix.inputtype }}/*.nf.test --tap=test.tap
 


### PR DESCRIPTION
Removing `conda clean` task from CI seemed to stop the random conda-related crashes in another pipeline, so I'm doing the same here. Fingers crossed.