### PR TITLE
Add t2t hsa

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Currently supported are:
 |flag | species | source|
 |-----|---------|-------|
 |hsa  | _Homo sapiens_       | [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly] |
+|t2t  | _Homo sapiens_       | [[T2T Consortium](https://sites.google.com/ucsc.edu/t2tworkinggroup/): T2T-CHM13v2.0 (file: chm13v2.0.fa.gz), datasets released along the v2.0 and the T2T-Y chromosome, see [paper](https://doi.org/10.1101/2022.12.01.518724)] |
 |mmu  | _Mus musculus_       | [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly] |
 |csa  | _Chlorocebus sabeus_ | [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic] |
 |gga  | _Gallus gallus_      | [NCBI: Gallus_gallus.GRCg6a.dna.toplevel] |
@@ -101,7 +102,7 @@ Included in this repository are:
 | eno | ONT RNA-Seq reads |yeast ENO2 Enolase II of strain S288C, YHR174W| https://raw.githubusercontent.com/rki-mf1/clean/master/controls/S288C_YHR174W_ENO2_coding.fsa |
 | phix| Illumina reads |enterobacteria_phage_phix174_sensu_lato_uid14015, NC_001422| ftp://ftp.ncbi.nlm.nih.gov/genomes/Viruses/enterobacteria_phage_phix174_sensu_lato_uid14015/NC_001422.fna |
 
-... for reasons. More can be easily added! Just write me, add an issue or make a pull request.
+... for reasons. More can be easily added! Just write us, add an issue or make a pull request.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ Currently supported are:
 
 |flag | species | source|
 |-----|---------|-------|
-|hsa  | _Homo sapiens_       | [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly] |
-|t2t  | _Homo sapiens_       | [[T2T Consortium](https://sites.google.com/ucsc.edu/t2tworkinggroup/): T2T-CHM13v2.0 (T2T-CHM13+Y, file name: chm13v2.0.fa.gz), datasets released along the v2.0 (T2T-CHM13) and the T2T-Y chromosome, see [paper](https://www.nature.com/articles/s41586-023-06457-y)] |
-|mmu  | _Mus musculus_       | [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly] |
-|csa  | _Chlorocebus sabeus_ | [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic] |
-|gga  | _Gallus gallus_      | [NCBI: Gallus_gallus.GRCg6a.dna.toplevel] |
-|cli  | _Columba livia_      | [NCBI: GCF_000337935.1_Cliv_1.0_genomic] |
+|hsa  | _Homo sapiens_       | [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly, incl. mtDNA] |
+|t2t  | _Homo sapiens_       | [[T2T Consortium](https://sites.google.com/ucsc.edu/t2tworkinggroup/): T2T-CHM13v2.0 (T2T-CHM13+Y, file name: GCA_009914755.4_T2T-CHM13v2.0_genomic), datasets released along the v2.0 (T2T-CHM13) and the T2T-Y chromosome, see [paper](https://www.nature.com/articles/s41586-023-06457-y), incl. mtDNA] |
+|mmu  | _Mus musculus_       | [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly, incl. mtDNA] |
+|csa  | _Chlorocebus sabeus_ | [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic, incl. mtDNA] |
+|gga  | _Gallus gallus_      | [NCBI: Gallus_gallus.GRCg6a.dna.toplevel, incl. mtDNA] |
+|cli  | _Columba livia_      | [NCBI: GCF_000337935.1_Cliv_1.0_genomic, incl. mtDNA] |
 |eco  | _Escherichia coli_   | [Ensembl: Escherichia_coli_k_12.ASM80076v1.dna.toplevel] |
 |sc2  | _SARS-CoV-2_         | [ENA Sequence: MN908947.3 (Wuhan-Hu-1 complete genome) [web](https://www.ebi.ac.uk/ena/browser/view/MN908947.3) [fasta](https://www.ebi.ac.uk/ena/browser/api/fasta/MN908947.3?download=true)] |
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Currently supported are:
 |flag | species | source|
 |-----|---------|-------|
 |hsa  | _Homo sapiens_       | [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly] |
-|t2t  | _Homo sapiens_       | [[T2T Consortium](https://sites.google.com/ucsc.edu/t2tworkinggroup/): T2T-CHM13v2.0 (file: chm13v2.0.fa.gz), datasets released along the v2.0 and the T2T-Y chromosome, see [paper](https://doi.org/10.1101/2022.12.01.518724)] |
+|t2t  | _Homo sapiens_       | [[T2T Consortium](https://sites.google.com/ucsc.edu/t2tworkinggroup/): T2T-CHM13v2.0 (T2T-CHM13+Y, file name: chm13v2.0.fa.gz), datasets released along the v2.0 (T2T-CHM13) and the T2T-Y chromosome, see [paper](https://www.nature.com/articles/s41586-023-06457-y)] |
 |mmu  | _Mus musculus_       | [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly] |
 |csa  | _Chlorocebus sabeus_ | [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic] |
 |gga  | _Gallus gallus_      | [NCBI: Gallus_gallus.GRCg6a.dna.toplevel] |

--- a/clean.nf
+++ b/clean.nf
@@ -254,7 +254,7 @@ def helpMSG() {
     ${c_green}--host${c_reset}         Comma separated list of reference genomes for decontamination, downloaded based on this parameter [default: $params.host]
                                         ${c_dim}Currently supported are:
                                         - hsa [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly]
-                                        - t2t ["Telomere-to-Telomere" (T2T) Consortium: T2T-CHM13v2.0 (T2T-CHM13+Y) human genome with additional 200 Mbp, closed gaps, and more complete Y]
+                                        - t2t [T2T Consortium: human genome w/ additional 200 Mbp, closed gaps, and more complete Y (T2T-CHM13+Yv2.0)]
                                         - mmu [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly]
                                         - csa [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic]
                                         - gga [NCBI: Gallus_gallus.GRCg6a.dna.toplevel]

--- a/clean.nf
+++ b/clean.nf
@@ -253,12 +253,12 @@ def helpMSG() {
     ${c_yellow}Decontamination options:${c_reset}
     ${c_green}--host${c_reset}         Comma separated list of reference genomes for decontamination, downloaded based on this parameter [default: $params.host]
                                         ${c_dim}Currently supported are:
-                                        - hsa [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly]
-                                        - t2t [T2T Consortium: human genome w/ additional 200 Mbp, closed gaps, and more complete Y (T2T-CHM13+Yv2.0)]
-                                        - mmu [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly]
-                                        - csa [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic]
-                                        - gga [NCBI: Gallus_gallus.GRCg6a.dna.toplevel]
-                                        - cli [NCBI: GCF_000337935.1_Cliv_1.0_genomic]
+                                        - hsa [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly, incl. mtDNA]
+                                        - t2t [T2T Consortium: human genome w/ additional 200 Mbp, closed gaps, and more complete Y (T2T-CHM13+Yv2.0), incl. mtDNA]
+                                        - mmu [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly, incl. mtDNA]
+                                        - csa [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic, incl. mtDNA]
+                                        - gga [NCBI: Gallus_gallus.GRCg6a.dna.toplevel, incl. mtDNA]
+                                        - cli [NCBI: GCF_000337935.1_Cliv_1.0_genomic, incl. mtDNA]
                                         - eco [Ensembl: Escherichia_coli_k_12.ASM80076v1.dna.toplevel]
                                         - sc2 [ENA: MN908947.3 (Wuhan-Hu-1 complete genome)]${c_reset}
     ${c_green}--control${c_reset}       Comma separated list of common controls used in Illumina or Nanopore sequencing [default: $params.control]

--- a/clean.nf
+++ b/clean.nf
@@ -79,7 +79,7 @@ if ( workflow.profile.contains('singularity') ) {
 }
 
 Set controls = ['phix', 'dcs', 'eno']
-Set hosts = ['hsa', 'mmu', 'cli', 'csa', 'gga', 'eco', 'sc2']
+Set hosts = ['hsa', 'mmu', 'cli', 'csa', 'gga', 'eco', 'sc2', 't2t']
 Set input_types = ['nano', 'illumina', 'illumina_single_end', 'fasta']
 
 if ( params.profile ) { exit 1, "--profile is wrong, use -profile" }
@@ -254,6 +254,7 @@ def helpMSG() {
     ${c_green}--host${c_reset}         Comma separated list of reference genomes for decontamination, downloaded based on this parameter [default: $params.host]
                                         ${c_dim}Currently supported are:
                                         - hsa [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly]
+                                        - t2t ["Telomere-to-Telomere" (T2T) Consortium: T2T-CHM13v2.0, datasets released along the v2.0 and the T2T-Y chromosome]
                                         - mmu [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly]
                                         - csa [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic]
                                         - gga [NCBI: Gallus_gallus.GRCg6a.dna.toplevel]

--- a/clean.nf
+++ b/clean.nf
@@ -254,7 +254,7 @@ def helpMSG() {
     ${c_green}--host${c_reset}         Comma separated list of reference genomes for decontamination, downloaded based on this parameter [default: $params.host]
                                         ${c_dim}Currently supported are:
                                         - hsa [Ensembl: Homo_sapiens.GRCh38.dna.primary_assembly]
-                                        - t2t ["Telomere-to-Telomere" (T2T) Consortium: T2T-CHM13v2.0, datasets released along the v2.0 and the T2T-Y chromosome]
+                                        - t2t ["Telomere-to-Telomere" (T2T) Consortium: T2T-CHM13v2.0 (T2T-CHM13+Y) human genome with additional 200 Mbp, closed gaps, and more complete Y]
                                         - mmu [Ensembl: Mus_musculus.GRCm38.dna.primary_assembly]
                                         - csa [NCBI: GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic]
                                         - gga [NCBI: Gallus_gallus.GRCg6a.dna.toplevel]

--- a/configs/node.config
+++ b/configs/node.config
@@ -3,8 +3,9 @@ process {
     withLabel: bbmap {      cpus = 24;  memory = 24.GB }
     withLabel: smallTask {  cpus = 1;   memory = 2.GB }
     withLabel: pysam {      cpus = 2;   memory = 4.GB }
-    withLabel: fastqc {     cpus = 2;   memory = 4.GB }
+    withLabel: fastqc { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' } }
     withLabel: multiqc {    cpus = 4;   memory = 4.GB }
     withLabel: nanoplot{    cpus = 8;   memory = 8.GB }
     withLabel: quast{       cpus = 8;   memory = 8.GB }
 }
+

--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -39,6 +39,9 @@ process download_host {
       wget "https://www.ebi.ac.uk/ena/browser/api/fasta/MN908947.3?download=true" -O host-temp.fa
       gzip host-temp.fa
       ;;
+    t2t)
+      wget https://s3-us-west-2.amazonaws.com/human-pangenomics/T2T/CHM13/assemblies/analysis_set/chm13v2.0.fa.gz -O host-temp.fa.gz
+      ;;
     *)
       echo "Unknown host ($host)."
       ;;

--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -40,7 +40,7 @@ process download_host {
       gzip host-temp.fa
       ;;
     t2t)
-      wget https://s3-us-west-2.amazonaws.com/human-pangenomics/T2T/CHM13/assemblies/analysis_set/chm13v2.0.fa.gz -O host-temp.fa.gz
+       wget https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/009/914/755/GCA_009914755.4_T2T-CHM13v2.0/GCA_009914755.4_T2T-CHM13v2.0_genomic.fna.gz -O host-temp.fa.gz
       ;;
     *)
       echo "Unknown host ($host)."

--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -18,29 +18,29 @@ process download_host {
   """
   case $host in
     hsa)
-      wget ftp://ftp.ensembl.org/pub/release-99/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz -O host-temp.fa.gz
+      wget 'ftp://ftp.ensembl.org/pub/release-99/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz' -O host-temp.fa.gz
       ;;
     mmu)
-      wget ftp://ftp.ensembl.org/pub/release-99/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna.primary_assembly.fa.gz -O host-temp.fa.gz
+      wget 'ftp://ftp.ensembl.org/pub/release-99/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna.primary_assembly.fa.gz' -O host-temp.fa.gz
       ;;
     cli)
-      wget ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/337/935/GCF_000337935.1_Cliv_1.0/GCF_000337935.1_Cliv_1.0_genomic.fna.gz -O host-temp.fa.gz
+      wget 'ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/337/935/GCF_000337935.1_Cliv_1.0/GCF_000337935.1_Cliv_1.0_genomic.fna.gz' -O host-temp.fa.gz
       ;;
     csa)
-      wget ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/409/795/GCF_000409795.2_Chlorocebus_sabeus_1.1/GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic.fna.gz -O host-temp.fa.gz
+      wget 'ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/409/795/GCF_000409795.2_Chlorocebus_sabeus_1.1/GCF_000409795.2_Chlorocebus_sabeus_1.1_genomic.fna.gz' -O host-temp.fa.gz
       ;;
     gga)
-      wget ftp://ftp.ensembl.org/pub/release-99/fasta/gallus_gallus/dna/Gallus_gallus.GRCg6a.dna.toplevel.fa.gz -O host-temp.fa.gz
+      wget 'ftp://ftp.ensembl.org/pub/release-99/fasta/gallus_gallus/dna/Gallus_gallus.GRCg6a.dna.toplevel.fa.gz' -O host-temp.fa.gz
       ;;
     eco)
-      wget ftp://ftp.ensemblgenomes.org/pub/release-45/bacteria//fasta/bacteria_90_collection/escherichia_coli_k_12/dna/Escherichia_coli_k_12.ASM80076v1.dna.toplevel.fa.gz -O host-temp.fa.gz
+      wget 'ftp://ftp.ensemblgenomes.org/pub/release-45/bacteria//fasta/bacteria_90_collection/escherichia_coli_k_12/dna/Escherichia_coli_k_12.ASM80076v1.dna.toplevel.fa.gz' -O host-temp.fa.gz
       ;;
     sc2)
-      wget "https://www.ebi.ac.uk/ena/browser/api/fasta/MN908947.3?download=true" -O host-temp.fa
+      wget 'https://www.ebi.ac.uk/ena/browser/api/fasta/MN908947.3?download=true' -O host-temp.fa
       gzip host-temp.fa
       ;;
     t2t)
-       wget https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/009/914/755/GCA_009914755.4_T2T-CHM13v2.0/GCA_009914755.4_T2T-CHM13v2.0_genomic.fna.gz -O host-temp.fa.gz
+       wget 'https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/009/914/755/GCA_009914755.4_T2T-CHM13v2.0/GCA_009914755.4_T2T-CHM13v2.0_genomic.fna.gz' -O host-temp.fa.gz
       ;;
     *)
       echo "Unknown host ($host)."


### PR DESCRIPTION
The T2T human genome is more complate than the GrCH38. In the paper, they show that it has 200 Mbp more, closes gaps, and they recently added a more complete Y chromosome. 

I implemented this as another option for auto-download. Tested the pipeline on a small nanopore example data set. 

Currently, Christian in Jena is running tests using some spike-in human data so we will see soon if a more complete human T2T genome helps to decontaminate more human reads (also for the paper). 

If you dont see any problems, we can then also merge this (into `dev` first, and later `main`, right?)