### PR TITLE
Increase ram

### DIFF
--- a/configs/node.config
+++ b/configs/node.config
@@ -1,6 +1,6 @@
 process {
     withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
-    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {12.GB * task.attempt}; maxRetries = 5 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
+    withLabel: bbmap        { cpus = {250 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 5 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
     withLabel: smallTask    { cpus = 1;   memory = 2.GB }
     withLabel: pysam        { cpus = 2;   memory = 4.GB }
     withLabel: fastqc       { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' }; }

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,6 +1,6 @@
 process {
     withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
-    withLabel: bbmap        { cpus = {250 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 5 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
+    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {240.GB * task.attempt}; maxRetries = 5 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
     withLabel: smallTask    { cpus = 1;   memory = 2.GB }
     withLabel: pysam        { cpus = 2;   memory = 4.GB }
     withLabel: fastqc       { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' }; }

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,6 +1,6 @@
 process {
-    withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
-    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {240.GB * task.attempt}; maxRetries = 5 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
+    withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 || 130..140 ? 'retry' : 'terminate' }; }
+    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 6 ; errorStrategy = { task.exitStatus in 1 || 130..140 ? 'retry' : 'terminate' }; }
     withLabel: smallTask    { cpus = 1;   memory = 2.GB }
     withLabel: pysam        { cpus = 2;   memory = 4.GB }
     withLabel: fastqc       { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' }; }

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,11 +1,11 @@
 process {
-    withLabel: minimap2 {   cpus = 24;  memory = 24.GB }
-    withLabel: bbmap {      cpus = 24;  memory = 24.GB }
-    withLabel: smallTask {  cpus = 1;   memory = 2.GB }
-    withLabel: pysam {      cpus = 2;   memory = 4.GB }
-    withLabel: fastqc { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' } }
-    withLabel: multiqc {    cpus = 4;   memory = 4.GB }
-    withLabel: nanoplot{    cpus = 8;   memory = 8.GB }
-    withLabel: quast{       cpus = 8;   memory = 8.GB }
+    withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 3 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
+    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 3 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
+    withLabel: smallTask    { cpus = 1;   memory = 2.GB }
+    withLabel: pysam        { cpus = 2;   memory = 4.GB }
+    withLabel: fastqc       { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' }; }
+    withLabel: multiqc      { cpus = 4;   memory = 4.GB }
+    withLabel: nanoplot     { cpus = 8;   memory = 8.GB }
+    withLabel: quast        { cpus = 8;   memory = 8.GB }
 }
 

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,6 +1,6 @@
 process {
     withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
-    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
+    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
     withLabel: smallTask    { cpus = 1;   memory = 2.GB }
     withLabel: pysam        { cpus = 2;   memory = 4.GB }
     withLabel: fastqc       { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' }; }

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,6 +1,6 @@
 process {
     withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
-    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
+    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {12.GB * task.attempt}; maxRetries = 5 ; errorStrategy = { task.exitStatus in 1 || 137 ? 'retry' : 'terminate' }; }
     withLabel: smallTask    { cpus = 1;   memory = 2.GB }
     withLabel: pysam        { cpus = 2;   memory = 4.GB }
     withLabel: fastqc       { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' }; }

--- a/configs/node.config
+++ b/configs/node.config
@@ -1,6 +1,6 @@
 process {
-    withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 3 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
-    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 3 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
+    withLabel: minimap2     { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
+    withLabel: bbmap        { cpus = {24 * task.attempt}; memory = {24.GB * task.attempt}; maxRetries = 4 ; errorStrategy = { task.exitStatus in 1 ? 'retry' : 'terminate' }; }
     withLabel: smallTask    { cpus = 1;   memory = 2.GB }
     withLabel: pysam        { cpus = 2;   memory = 4.GB }
     withLabel: fastqc       { cpus = {2 * task.attempt}; memory = {4.GB * task.attempt } ; maxRetries = 3 ; errorStrategy = { task.exitStatus in 130..140 ? 'retry' : 'terminate' }; }


### PR DESCRIPTION
I experienced this problem before and just confirmed it while doing new analysis for MARRES. At least on the HPC, process might fail due to out of RAM and then error code 1 is thrown. 

With this change, I catch it and resume with more RAM. 

Disadvantage: when the process fails w/ error code 1 due to another problem, it will resume a few times but then still fail. 