### PR TITLE
Change check_own process to not include input files in output

### DIFF
--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -62,15 +62,15 @@ process check_own {
   path fasta
 
   output:
-  path '*.gz', includeInputs: true
+  path 'checked.fa.gz'
 
   script:
   """
-  seqkit seq ${fasta} -o ${fasta}.gz
+  seqkit seq ${fasta} -o checked.fa.gz
   """
   stub:
   """
-  touch ${fasta}.gz
+  touch checked.fa.gz
   """
 }
 


### PR DESCRIPTION
Resolves #107 

Only when you are using a self-provided reference file, you would get duplicates in your reference file at some point. This was caused by the `check_own` process, which did this: `seqkit seq {input} -o {output}.gz` and then returns any gzip files **including those in the input**. This causes a problem when the input file has a .gz extension, leading to both the input and seqkit output files being passed on to the next process, which combines both files together and renames any duplicates.

Resolved by disabling "includeInputs" and also I used a fixed output file name and explicitly passed that on. Feel free to tweak this change if you like but it should resolve the problem. 