### PR TITLE
Pin nf-test in the CI instead of installing the latest release

### DIFF
--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -46,10 +46,17 @@ jobs:
         with:
           version: "${{ matrix.NXF_VER }}"
 
+      # The install script resolved the latest release through the
+      # unauthenticated GitHub API, which is rate limited on shared runners and
+      # failed the job with `curl: (22) The requested URL returned error: 403`.
+      # This action takes a pinned version, so it needs no API call, and it
+      # caches the download in the tool cache.
       - name: Install nf-test
-        run: |
-          wget -qO- https://code.askimed.com/install/nf-test | bash
-          sudo mv nf-test /usr/local/bin/
+        uses: nf-core/setup-nf-test@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: "0.9.5"
 
       - name: Set up Singularity
         if: matrix.profile == 'singularity'


### PR DESCRIPTION
## Problem

The `Install nf-test` step runs:

```bash
wget -qO- https://code.askimed.com/install/nf-test | bash
```

Without a version argument that script resolves the latest release through `https://api.github.com/repos/askimed/nf-test/releases/latest` — unauthenticated. On shared GitHub runners that call gets rate limited, and because the script runs under `set -e` the whole job dies before a single test runs:

```
Run wget -qO- https://code.askimed.com/install/nf-test | bash
curl: (22) The requested URL returned error: 403
```

This happened on the CI of #124. It is unrelated to the pipeline itself and will come back at random.

## Change

Use [`nf-core/setup-nf-test`](https://github.com/nf-core/setup-nf-test) with a pinned version, mirroring how the workflow already installs Nextflow with `nf-core/setup-nextflow`:

- a pinned version means no API call to resolve "latest"
- the action caches the download in the runner tool cache
- `GITHUB_TOKEN` is set on that step so any API access it does make is authenticated

`0.9.5` is the version the CI has been resolving to anyway, so nothing changes about what is tested.

## Note

This touches the same workflow file as #124, but a different section (that PR only changes the `NXF_VER` matrix), so the two merge cleanly in either order.