### PR TITLE
Merge the --keep FASTAs into one reference

### DIFF
--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -84,18 +84,19 @@ process concat_contamination {
     mode: params.publish_dir_mode,
     pattern: "db.fa.gz",
     enabled: !params.no_intermediate,
-    saveAs: { "host.fa.gz" }
+    saveAs: { "${name}.fa.gz" }
   )
   publishDir (
     path: "${params.output}/intermediate",
     mode: params.publish_dir_mode,
     pattern: "db.fa.fai",
     enabled: !params.no_intermediate,
-    saveAs: { "host.fa.fai" }
+    saveAs: { "${name}.fa.fai" }
   )
 
   input:
   path fastas
+  val name
 
   output:
   path 'db.fa.gz', emit: fa

--- a/modules/prepare_contamination.nf
+++ b/modules/prepare_contamination.nf
@@ -62,15 +62,17 @@ process check_own {
   path fasta
 
   output:
-  path 'checked.fa.gz'
+  path "${fasta.baseName}.checked.fa.gz"
 
   script:
+  // the output is named after the input: with more than one --own/--keep FASTA
+  // a fixed name would collide when the checked files are staged together
   """
-  seqkit seq ${fasta} -o checked.fa.gz
+  seqkit seq ${fasta} -o ${fasta.baseName}.checked.fa.gz
   """
   stub:
   """
-  touch checked.fa.gz
+  touch ${fasta.baseName}.checked.fa.gz
   """
 }
 

--- a/workflows/keep_wf.nf
+++ b/workflows/keep_wf.nf
@@ -2,6 +2,7 @@ include { clean as keep_map } from './clean_wf'
 
 include { get_read_names; get_read_names_fastx; filter_fastq_by_name } from '../modules/utils'
 include { idxstats_from_bam ; flagstats_from_bam } from '../modules/alignment_processing'
+include { concat_contamination as concat_keep } from '../modules/prepare_contamination'
 
 workflow keep {
     take:
@@ -11,7 +12,13 @@ workflow keep {
         un_mapped_clean_fastq
 
     main:
-        keep_map(input, keep_reference, dcs_ends_bed, 'map-to-keep')
+        // The mappers read a single reference, so several --keep FASTAs have to
+        // be merged first. Passing the list on would silently use only the first
+        // one and drop the reads of all the others from the cleaned output. This
+        // is the same merge the contamination references go through.
+        concat_keep(keep_reference, 'keep')
+
+        keep_map(input, concat_keep.out.fa, dcs_ends_bed, 'map-to-keep')
 
         if ( params.bbduk ) {
           keep_reads_fastx = keep_map.out.out_reads.filter{ it[1] == 'mapped' }

--- a/workflows/prepare_contamination_wf.nf
+++ b/workflows/prepare_contamination_wf.nf
@@ -22,7 +22,7 @@ workflow prepare_contamination {
           .mix(illuminaControlFastaChannel)
           .mix(prepare_own_host.out)
           .mix(rRNAChannel).collect()
-    concat_contamination(contamination_collection)
+    concat_contamination(contamination_collection, 'host')
 
   emit:
     concat_contamination.out.fa


### PR DESCRIPTION
Fixes #129.

## What was wrong

The keep path handed the mapper the whole collected list of `--keep` FASTAs, while the contamination path merges its references into a single `db.fa.gz` first. The mappers read one reference, so `${db}` expanding to several files put the second FASTA where the query belongs.

It is worse than "only the first FASTA is used". minimap2 is always called with `--split-prefix`, and in that mode it reads **only the first query file**:

```
$ minimap2 -ax map-ont --split-prefix tmp ref.fa q1.fa q2.fa | grep -vc '^@'
1
$ minimap2 -ax map-ont              ref.fa q1.fa q2.fa | grep -vc '^@'
2
```

So with two `--keep` FASTAs the pipeline mapped keep-FASTA-2 against keep-FASTA-1 and never looked at the reads. Nothing was kept, silently.

## The fix

Run the collected keep references through the same concat the contamination references already use, inside `keep_wf` — `clean.nf` is untouched, so this does not collide with the `clean.nf` restructuring in #128. `concat_contamination` now takes the published name (`host` / `keep`) as an input, which is the only reason it needed a signature change.

The keep reference also gains the duplicate-sequence-ID renaming (`seqkit rename`) the contamination reference already had, and is published as `intermediate/keep.fa.gz`.

The first commit is a cherry-pick of the `check_own` naming fix already present in #124 and #128 — without it, several `--keep` files collide on `checked.fa.gz` before they ever reach the concat. Git merges the duplicate cleanly since the content is identical.

## Testing

Real runs (conda, not stubs) with 174k nanopore reads that are ~100% SARS-CoV-2, `--own sc2-ref.fa`, and the sc2 genome split into two keep FASTAs (positions 1-15000 and 15001-29903):

| run | clean (kept) | removed |
|---|---|---|
| no `--keep` | 72 | 171113 |
| two keep FASTAs, before | 72 | 171113 |
| two keep FASTAs, after | 171185 | 0 |
| one keep FASTA (first half only), after | 83967 | 87218 |

Before the fix, two keep FASTAs rescue nothing — the result is identical to not passing `--keep` at all. After, both halves are used and every read is rescued. The single-FASTA case still behaves as before, rescuing only the reads from the half it covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
